### PR TITLE
 #158: Implemented operator __eq__ for BucketPath to compare string representation

### DIFF
--- a/doc/changes/unreleased.md
+++ b/doc/changes/unreleased.md
@@ -1,1 +1,5 @@
 # Unreleased
+
+## Bugfixes
+
+* #158: Implemented operator `__eq__` for BucketPath to compare string representation

--- a/exasol/bucketfs/_path.py
+++ b/exasol/bucketfs/_path.py
@@ -401,6 +401,11 @@ class BucketPath:
         new_path = self._path / (other._path if isinstance(other, cls) else other)
         return cls(new_path, self._bucket_api)
 
+    def __eq__(self, other) -> bool:
+        if not isinstance(other, BucketPath):
+            return False
+        return (self._path, self._bucket_api) == (other._path, other._bucket_api)
+
     def __str__(self):
         return str(self._path)
 

--- a/test/unit/test_bucket_path.py
+++ b/test/unit/test_bucket_path.py
@@ -205,8 +205,14 @@ def test_archive_as_udf_path(bucket_fake):
     assert path.as_udf_path().endswith('container/my_container')
 
 
-def test_eq(bucket_fake):
+@pytest.mark.parametrize(
+    "file1,file2,expectation",
+    [
+        ('a.txt', 'b.txt', False),
+        ('a.txt', 'a.txt', True),
+    ])
+def test_eq(bucket_fake, file1, file2, expectation):
     path = bfs.path.BucketPath('dir', bucket_api=bucket_fake)
-    a = path / "dir1"
-    b = path / "dir1"
-    assert a == b
+    a = path / file1
+    b = path / file2
+    assert (a == b) == expectation

--- a/test/unit/test_bucket_path.py
+++ b/test/unit/test_bucket_path.py
@@ -203,3 +203,10 @@ def test_write_and_create_parent(bucket_fake):
 def test_archive_as_udf_path(bucket_fake):
     path = bfs.path.BucketPath('container/my_container.tar.gz', bucket_api=bucket_fake)
     assert path.as_udf_path().endswith('container/my_container')
+
+
+def test_eq(bucket_fake):
+    path = bfs.path.BucketPath('dir', bucket_api=bucket_fake)
+    a = path / "dir1"
+    b = path / "dir1"
+    assert a == b


### PR DESCRIPTION
Closes #158 

### Submission Checklist

* [x] Updated the changelog in file `doc/changes/unreleasd.md`

If required
* [x] Updated Documentation
* [x] Updated API Documentation

If doing a release
* [ ] Bumped version number using `poetry run nox -s prepare-release`
